### PR TITLE
Add Next.js landing page for HashCombinator

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# HashCombinator Landing Site
+
+This is a Next.js + Tailwind CSS landing site for **HashCombinator**, a crypto-native startup incubator. The goal is to attract founders, impress investors, and clearly explain how the incubator works.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+The site is optimized for dark mode and uses scroll animations built with Framer Motion.

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,13 @@
+export default function Footer() {
+  return (
+    <footer className="py-10 px-4 md:px-8 bg-opacity-20 backdrop-blur-md bg-white/5 text-center">
+      <div className="flex justify-center space-x-6 mb-4">
+        <a href="https://twitter.com" aria-label="Twitter" className="hover:text-neon">Twitter</a>
+        <a href="https://discord.com" aria-label="Discord" className="hover:text-neon">Discord</a>
+        <a href="https://youtube.com" aria-label="YouTube" className="hover:text-neon">YouTube</a>
+        <a href="https://linkedin.com" aria-label="LinkedIn" className="hover:text-neon">LinkedIn</a>
+      </div>
+      <p className="text-sm text-gray-400">© {new Date().getFullYear()} HashCombinator. All rights reserved.</p>
+    </footer>
+  );
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,31 @@
+import { motion } from 'framer-motion';
+
+export default function Hero() {
+  return (
+    <section className="min-h-screen flex flex-col items-center justify-center text-center px-4">
+      <motion.h1
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="text-4xl md:text-6xl font-bold mb-6 text-neon"
+      >
+        Crypto-Powered Startup Incubator
+      </motion.h1>
+      <motion.p
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.3 }}
+        className="max-w-xl text-lg md:text-xl mb-8"
+      >
+        We turn AI startups into Web3 ecosystems with memecoin-driven traction.
+      </motion.p>
+      <motion.a
+        href="#apply"
+        whileHover={{ scale: 1.05 }}
+        className="bg-neon text-base px-8 py-3 rounded-lg font-semibold text-black"
+      >
+        Apply Now
+      </motion.a>
+    </section>
+  );
+}

--- a/components/sections/LaunchShowcase.tsx
+++ b/components/sections/LaunchShowcase.tsx
@@ -1,0 +1,16 @@
+export default function LaunchShowcase() {
+  return (
+    <section className="py-20 px-4 md:px-8 bg-[#111]" id="showcase">
+      <h2 className="text-3xl md:text-4xl font-semibold mb-6 text-neon">
+        Previous Partners
+      </h2>
+      <p className="max-w-2xl mb-4">
+        Coming soon: showcases of startups that leveraged our memecoin model.
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="h-40 bg-gray-800 rounded-lg" />
+        <div className="h-40 bg-gray-800 rounded-lg" />
+      </div>
+    </section>
+  );
+}

--- a/components/sections/MemecoinAdvantages.tsx
+++ b/components/sections/MemecoinAdvantages.tsx
@@ -1,0 +1,20 @@
+export default function MemecoinAdvantages() {
+  const items = [
+    'Bootstraps liquidity quickly',
+    'Creates viral community narratives',
+    'Rewards early believers',
+  ];
+
+  return (
+    <section className="py-20 px-4 md:px-8 bg-[#111]" id="advantages">
+      <h2 className="text-3xl md:text-4xl font-semibold mb-6 text-neon">
+        Why Memecoins?
+      </h2>
+      <ul className="space-y-2 max-w-xl list-disc list-inside">
+        {items.map((i) => (
+          <li key={i}>{i}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/components/sections/Problem.tsx
+++ b/components/sections/Problem.tsx
@@ -1,0 +1,13 @@
+export default function Problem() {
+  return (
+    <section className="py-20 px-4 md:px-8" id="problem">
+      <h2 className="text-3xl md:text-4xl font-semibold text-orange mb-4">
+        Web2 AI Startups Lack Web3 Traction
+      </h2>
+      <p className="max-w-2xl">
+        Traditional AI companies struggle to break into crypto. They need Web3-n
+        ative funding, culture, and distribution to succeed.
+      </p>
+    </section>
+  );
+}

--- a/components/sections/Process.tsx
+++ b/components/sections/Process.tsx
@@ -1,0 +1,36 @@
+const phases = [
+  {
+    title: 'Curate Scalable Startups',
+    desc: 'We select AI teams with Web3 potential.',
+  },
+  {
+    title: 'Build MVPs',
+    desc: 'We design, code, and ship first versions fast.',
+  },
+  {
+    title: 'Launch Memecoins Strategically',
+    desc: 'Ignite communities and raise early capital.',
+  },
+  {
+    title: 'Drive Narrative & Distribution',
+    desc: 'Dominate CT and Web3 discourse with culture.',
+  },
+];
+
+export default function Process() {
+  return (
+    <section className="py-20 px-4 md:px-8" id="process">
+      <h2 className="text-3xl md:text-4xl font-semibold mb-8 text-orange">
+        Our 4-Phase Process
+      </h2>
+      <ol className="space-y-6 max-w-2xl">
+        {phases.map((p) => (
+          <li key={p.title} className="border-l-4 border-neon pl-4">
+            <h3 className="text-xl font-semibold">{p.title}</h3>
+            <p>{p.desc}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/components/sections/Team.tsx
+++ b/components/sections/Team.tsx
@@ -1,0 +1,20 @@
+export default function Team() {
+  const members = [
+    { name: 'Alice', title: 'Founder' },
+    { name: 'Bob', title: 'CTO' },
+  ];
+  return (
+    <section className="py-20 px-4 md:px-8" id="team">
+      <h2 className="text-3xl md:text-4xl font-semibold mb-6 text-orange">Meet the Team</h2>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-8 max-w-4xl">
+        {members.map((m) => (
+          <div key={m.name} className="text-center">
+            <div className="w-24 h-24 mx-auto bg-gray-800 rounded-full mb-2" />
+            <h3 className="font-semibold">{m.name}</h3>
+            <p className="text-sm text-gray-400">{m.title}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "hashcombinator",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.0",
+    "@types/react": "18.2.21",
+    "@types/node": "20.2.5",
+    "typescript": "5.2.2",
+    "eslint": "8.45.0",
+    "eslint-config-next": "13.5.0"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '@/styles/globals.css';
+import type { AppProps } from 'next/app';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,28 @@
+import Head from 'next/head';
+import Hero from '@/components/Hero';
+import Problem from '@/components/sections/Problem';
+import MemecoinAdvantages from '@/components/sections/MemecoinAdvantages';
+import Process from '@/components/sections/Process';
+import LaunchShowcase from '@/components/sections/LaunchShowcase';
+import Team from '@/components/sections/Team';
+import Footer from '@/components/Footer';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>HashCombinator</title>
+        <meta name="description" content="Crypto-native startup incubator" />
+      </Head>
+      <main>
+        <Hero />
+        <Problem />
+        <MemecoinAdvantages />
+        <Process />
+        <LaunchShowcase />
+        <Team />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-base text-white font-sans;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,20 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        base: '#0A0A0F',
+        neon: '#7FFF00',
+        orange: '#FF7E1B'
+      },
+      fontFamily: {
+        sans: ['InterVariable', 'sans-serif']
+      }
+    },
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize Next.js project skeleton with Tailwind CSS
- add hero, process, advantages, showcase, team, and footer sections
- include basic global styles and config files

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848a6f2aeb08331a35e3af8fc9b3049