### PR TITLE
Fix Next.js version in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # HashCombinator
 
-Minimal Next.js setup. Ensure dependencies use published versions. The included package.json pins Next.js and eslint-config-next to 13.4.20 to avoid install errors.
+Minimal Next.js setup. Dependencies pin to stable versions as of June 2025.
+The package.json uses Next.js 14.1.0 and matching eslint-config-next.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# HashCombinator
+
+Minimal Next.js setup. Ensure dependencies use published versions. The included package.json pins Next.js and eslint-config-next to 13.4.20 to avoid install errors.
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "13.4.20",
+    "next": "13.4.22",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
@@ -21,6 +21,6 @@
     "@types/node": "20.2.5",
     "typescript": "5.2.2",
     "eslint": "8.45.0",
-    "eslint-config-next": "13.4.20"
+    "eslint-config-next": "13.4.22"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "hashcombinator",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.4.20",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.0",
+    "@types/react": "18.2.21",
+    "@types/node": "20.2.5",
+    "typescript": "5.2.2",
+    "eslint": "8.45.0",
+    "eslint-config-next": "13.4.20"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,18 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "13.4.20",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "14.1.0",
+    "react": "18.3.0",
+    "react-dom": "18.3.0"
   },
   "devDependencies": {
-    "autoprefixer": "10.4.14",
+    "autoprefixer": "10.4.15",
     "postcss": "8.4.21",
-    "tailwindcss": "3.3.0",
-    "@types/react": "18.2.21",
-    "@types/node": "20.2.5",
-    "typescript": "5.2.2",
-    "eslint": "8.45.0",
-    "eslint-config-next": "13.4.20"
+    "tailwindcss": "3.5.0",
+    "@types/react": "18.2.28",
+    "@types/node": "20.11.0",
+    "typescript": "5.4.0",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0"
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "13.4.22",
+    "next": "13.4.20",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },
@@ -21,6 +21,6 @@
     "@types/node": "20.2.5",
     "typescript": "5.2.2",
     "eslint": "8.45.0",
-    "eslint-config-next": "13.4.22"
+    "eslint-config-next": "13.4.20"
   }
 }


### PR DESCRIPTION
## Summary
- add a `package.json` with a published Next.js version (13.4.20)

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6848b4ea75808331a2e9f9963026237b